### PR TITLE
feat: set up Docusaurus documentation site

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,0 +1,22 @@
+import {themes as prismThemes} from "prism-react-renderer";
+
+const config = {
+  title: "Richmond Developer Docs",
+  tagline: "API reference, guides, and runbooks",
+  url: "https://docs.richmond.dev",
+  baseUrl: "/",
+  organizationName: "afcrichmond-labs",
+  projectName: "richmond-docs",
+  themeConfig: {
+    navbar: {
+      title: "Richmond Docs",
+      items: [
+        { type: "doc", docId: "getting-started", label: "Guides" },
+        { to: "/api", label: "API Reference" },
+        { to: "/runbooks", label: "Runbooks" },
+      ],
+    },
+  },
+};
+
+export default config;


### PR DESCRIPTION
## Summary
Initial Docusaurus v3 setup for the developer documentation site.

## Sections
- Getting Started
- API Reference (auto-generated from OpenAPI)
- Guides
- Runbooks
- Architecture

## Related
- Resolves #2
- **Linear:** RIC-285